### PR TITLE
Library report, formatting, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,82 @@ Server, username and password may be loaded from a [Hammer CLI configuration fil
 ↪ ./sat6Inventory.py -f [path/to/config.yml]
 ~~~
 
+# Output
+
+## Basic report
+
+| Column | Description |
+|--------|-------------|
+| system_id | Server ID |
+| org_id | Organization ID which is server registered to |
+| name | Name of the server |
+| security | Number of security updates available |
+| bug | Number of bug fixes available |
+| enhancement | Number of enhancements available |
+| score | Total system score |
+| content_view | Name of the Content View server is registered to |
+| content_view_publish_date | Date on which the Content View was published |
+| lifecycle_environment | Name of the Lifecycle Environment server is registered to |
+| subscription_os_release | |
+| os_release | |
+| arch | CPU architecture |
+| subscription_status | |
+| comment | |
+
+## Advanced report
+
+| Column | Description |
+|--------|-------------|
+| system_id | Server ID |
+| org_id | Organization ID which is server registered to |
+| name | Name of the server |
+| critical | Number of critical security updates available |
+| important | Number of important security updates available |
+| moderate | Number of moderate importance security updates available |
+| low | Number of low importance security updates available |
+| bug | Number of bug fixes available |
+| enhancement | Number of enhancements available |
+| score | Total system score |
+| content_view | Name of the Content View server is registered to |
+| content_view_publish_date | Date on which the Content View was published |
+| lifecycle_environment | Name of the Lifecycle Environment server is registered to |
+| subscription_os_release |  |
+| os_release |  |
+| arch | CPU architecture |
+| subscription_status |  |
+| comment |  |
+
+## Library report
+
+| Column | Description |
+|--------|-------------|
+| system_id | Server ID |
+| org_id | Organization ID which is server registered to |
+| name | Name of the server |
+| critical | Number of critical security updates available |
+| important | Number of important security updates available |
+| moderate | Number of moderate importance security updates available |
+| low | Number of low importance security updates available |
+| bug | Number of bug fixes available |
+| enhancement | Number of enhancements available |
+| score | Total system score |
+| total_applicable_security | |
+| applicable_critical | Number of critical security updates applicable |
+| applicable_important | Number of important security updates applicable |
+| applicable_moderate | Number of moderate security updates applicable |
+| applicable_low | Number of low security updates applicable |
+| applicable_bug | Number of bug fixes applicable |
+| applicable_enhancement | Number of enhancements applicable |
+ |applicable_score | Total score of applicable errata |
+| content_view | Name of the Content View server is registered to |
+| content_view_publish_date | Date on which the Content View was published |
+| lifecycle_environment | Name of the Lifecycle Environment server is registered to |
+| subscription_os_release |  |
+| os_release |  |
+| arch | CPU architecture |
+| subscription_status |  |
+| comment |  |
+
 # Scores
 A score is shown for each host, based on the number and severity of outstanding errata. Each errata adds the factor for its severity. The advanced report differentiates security errata based on their severity level.
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,76 @@
 # sat6-currency
 Satellite 6 version of 'spacewalk-report system-currency'
+
+## Requirements
+* Python 2.x
+* [Requests](http://python-requests.org/)
+* [PyYAML](https://pyyaml.org/)
+
+## Usage
+Specify server and username on commandline. The script will prompt for password.
+```bash
+python sat6-currency.py -n satellite.example.com -u admin
+```
+
+Load server, username and password from a [Hammer CLI configuration file](https://github.com/theforeman/hammer-cli-foreman/blob/master/doc/configuration.md). Default path is `~/.hammer/cli_config.yml`.
+```bash
+python sat6-currency.py -c [path/to/config.yml]
+```
+
+Use advanced mode to divide security errata by severity.
+```bash
+python sat6-currency.py -c --advanced
+```
+
+## Output
+The script outputs csv to stdout.
+
+### Scores
+A score is shown for each host, based on the number and severity of outstanding errata. Each errata adds the factor for its severity. Simple (default) and advanced mode calculates scores differently.
+
+#### Simple mode factors
+
+| Severity | Factor |
+|----------|-------:|
+| security | 8 |
+| bug fix | 2 |
+| enhancement | 1 |
+
+#### Advanced mode factors
+
+| Severity | Factor |
+|----------|-------:|
+| security: critical | 32 |
+| security: important | 16 |
+| security: moderate | 8 |
+| security: low | 4 |
+| bug fix | 2 |
+| enhancement | 1 |
+
+## Help Output
+```
+$ python sat6-currency.py
+usage: sat6-currency.py [-h] [-a] [-c [CONFIG]] [-n SERVER] [-u USERNAME]
+                        [-p PASSWORD] [-s SEARCH]
+
+Satellite 6 version of 'spacewalk-report system-currency'
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -a, --advanced        Use this flag if you want to divide security errata by
+                        severity. Note: this will reduce performance if this
+                        script significantly.
+  -c [CONFIG], --config [CONFIG]
+                        Hammer CLI config file (defaults to
+                        ~/.hammer/cli_config.yml
+  -n SERVER, --server SERVER
+                        Satellite server
+  -u USERNAME, --username USERNAME
+                        Username to access Satellite
+  -p PASSWORD, --password PASSWORD
+                        Password to access Satellite. The user will be asked
+                        interactively if password is not provided.
+  -s SEARCH, --search SEARCH
+                        Search string for host.( like
+                        ?search=lifecycle_environment=Test
+```

--- a/README.md
+++ b/README.md
@@ -16,13 +16,13 @@ A CSV file is printed on stdout listing each system with details of the number o
 ~~~
 
 ## Advanced report
-A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are available on each host.  The report takes longer to run, but shows the breakdown of security errata by critical, important, moderate and low levels.
+A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are available on each host.  The report takes longer to run, but shows the breakdown of security errata by critical, important, moderate and low severity levels.
 
 ~~~
 ↪ ./sat6Inventory.py -a -n SERVER -u USERNAME [-p PASSWORD] -o 'MyOrganization'
 ~~~
 ## Library report
-A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are both available and applicable to each host.  The report takes longer to run, but shows the breakdown of security errata by critical, important, moderate and low severity.  In addition, two CSV files are generated in the working directory listing available and applicable errata for each host.
+A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are both available and applicable to each host.  The report takes longer to run, but shows the breakdown of security errata by critical, important, moderate and low severity levels.  In addition, two CSV files are generated in the working directory listing available and applicable errata for each host.
 
 ~~~
 ↪ ./sat6Inventory.py -l -n SERVER -u USERNAME [-p PASSWORD] -o 'MyOrganization'

--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ Server, username and password may be loaded from a [Hammer CLI configuration fil
 ~~~
 
 # Output
+The tables below describe the meaning of each column in the output.
+
+Available errata, also known as installable errata, are those in a server's content view which are able to be installed.
+Applicable errata are those in the Library or reference content view which are applicable to the server.
 
 ## Basic report
 
@@ -89,6 +93,7 @@ Server, username and password may be loaded from a [Hammer CLI configuration fil
 | system_id | Server ID |
 | org_id | Organization ID which is server registered to |
 | name | Name of the server |
+| total_available_security | Total number of security updates available Total number of security updates available |
 | critical | Number of critical security updates available |
 | important | Number of important security updates available |
 | moderate | Number of moderate importance security updates available |
@@ -96,7 +101,7 @@ Server, username and password may be loaded from a [Hammer CLI configuration fil
 | bug | Number of bug fixes available |
 | enhancement | Number of enhancements available |
 | score | Total system score |
-| total_applicable_security | |
+| total_applicable_security | Total number of security updates applicable |
 | applicable_critical | Number of critical security updates applicable |
 | applicable_important | Number of important security updates applicable |
 | applicable_moderate | Number of moderate security updates applicable |
@@ -113,20 +118,37 @@ Server, username and password may be loaded from a [Hammer CLI configuration fil
 | subscription_status |  |
 | comment |  |
 
+### Errata report
+
+| Column | Description |
+|--------|-------------|
+| system_id | Server ID |
+| org_id | Organization ID which is server registered to |
+| name | Name of the server |
+| state | State of the errata: Available or Applicable |
+| errata_id | ID of the errata|
+| issued | Date the errata was issued |
+| updated | Date the errata was updated |
+| severity | Errata security severity |
+| type | Errata type |
+| reboot_suggested | Does the errata suggest rebooting the system after installation |
+| title | Title of the errata |
+| further_info | URL to errata information web page |
+
 # Scores
-A score is shown for each host, based on the number and severity of outstanding errata. Each errata adds the factor for its severity. The advanced report differentiates security errata based on their severity level.
+A score is shown for each host, based on the number and type of outstanding errata. Each errata adds the factor for its type. The advanced report differentiates security errata based on their severity.
 
 ## Basic report factors
 
-| Severity    | Factor |
-|-------------|-------:|
-| Security    |      8 |
-| Bug Fix     |      2 |
-| Enhancement |      1 |
+| Type/Severity | Factor |
+|---------------|-------:|
+| Security      |      8 |
+| Bug Fix       |      2 |
+| Enhancement   |      1 |
 
 ## Advanced report factors
 
-| Severity            | Factor |
+| Type/Severity       | Factor |
 |---------------------|-------:|
 | Security: Critical  |     32 |
 | Security: Important |     16 |

--- a/README.md
+++ b/README.md
@@ -37,28 +37,27 @@ Server, username and password may be loaded from a [Hammer CLI configuration fil
 ↪ ./sat6Inventory.py -f [path/to/config.yml]
 ~~~
 
-# Output
-## Scores
-A score is shown for each host, based on the number and severity of outstanding errata. Each errata adds the factor for its severity. Simple (default) and advanced mode calculates scores differently.
+# Scores
+A score is shown for each host, based on the number and severity of outstanding errata. Each errata adds the factor for its severity. The advanced report differentiates security errata based on their severity level.
 
-### Basic report factors
+## Basic report factors
 
-| Severity | Factor |
-|----------|-------:|
-| security | 8 |
-| bug fix | 2 |
-| enhancement | 1 |
+| Severity    | Factor |
+|-------------|-------:|
+| Security    |      8 |
+| Bug Fix     |      2 |
+| Enhancement |      1 |
 
-### Advanced report factors
+## Advanced report factors
 
-| Severity | Factor |
-|----------|-------:|
-| security: critical | 32 |
-| security: important | 16 |
-| security: moderate | 8 |
-| security: low | 4 |
-| bug fix | 2 |
-| enhancement | 1 |
+| Severity            | Factor |
+|---------------------|-------:|
+| Security: Critical  |     32 |
+| Security: Important |     16 |
+| Security: Moderate  |      8 |
+| Security: Low       |      4 |
+| Bug Fix             |      2 |
+| Enhancement         |      1 |
 
 # Notes
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # sat6-currency
-Satellite 6 version of 'spacewalk-report system-currency'. 
+Satellite 6 version of 'spacewalk-report system-currency'
 
 # Requirements
 

--- a/README.md
+++ b/README.md
@@ -1,2 +1,67 @@
 # sat6-currency
+Satellite 6 version of 'spacewalk-report system-currency'. 
+
+# Requirements
+
+* python-requests
+
+Tested from RHEL 7.4 against Satellite 6.2.12.
+
+# Usage
+## Basic report
+A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are available on each host.
+
+~~~
+↪ ./sat6Inventory.py -n SERVER -u USERNAME [-p PASSWORD]
+~~~
+
+## Advanced report
+A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are available on each host.  The report takes longer to run, but shows the breakdown of security errata by critical, important, moderate and low levels.
+
+~~~
+↪ ./sat6Inventory.py -a -n SERVER -u USERNAME [-p PASSWORD] -o 'MyOrganization'
+~~~
+## Library report
+A CSV file is printed on stdout listing each system with details of the number of security, bug and enhancement errata that are both available and applicable to each host.  The report takes longer to run, but shows the breakdown of security errata by critical, important, moderate and low severity.  In addition, two CSV files are generated in the working directory listing available and applicable errata for each host.
+
+~~~
+↪ ./sat6Inventory.py -l -n SERVER -u USERNAME [-p PASSWORD] -o 'MyOrganization'
+~~~
+
+# Help Output
+
+~~~
+↪ ./sat6-currency.py -h
+usage: sat6-currency.py [-h] [-a] -n SERVER -u USERNAME [-p PASSWORD] [-l]
+                        [-o ORGANIZATION] [-c CONTENTVIEW] [-e ENVIRONMENT]
+
 Satellite 6 version of 'spacewalk-report system-currency'
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -a, --advanced        Use this flag if you want to divide security errata by
+                        severity. Note: this will reduce performance of this
+                        script significantly.
+  -n SERVER, --server SERVER
+                        Satellite server (defaults to localhost)
+  -u USERNAME, --username USERNAME
+                        Username to access Satellite
+  -p PASSWORD, --password PASSWORD
+                        Password to access Satellite. The user will be asked
+                        interactively if password is not provided.
+  -l, --library         Use this flag to also report on Library Synced Content
+                        AND to divide security errata by severity. Note: this
+                        will reduce performance of this script significantly.
+                        Use with -o, -e and -c options
+  -o ORGANIZATION, --organization ORGANIZATION
+                        Organization to use when using the '-l' option
+  -c CONTENTVIEW, --contentview CONTENTVIEW
+                        Content View to use using the '-l' option. Default:
+                        Default Organization View
+  -e ENVIRONMENT, --environment ENVIRONMENT
+                        Environment to use with the '-l' option. Default:
+                        Library
+~~~
+# Notes
+
+* The script will prompt for password if not provided

--- a/README.md
+++ b/README.md
@@ -1,2 +1,46 @@
 # sat6-currency
 Satellite 6 version of 'spacewalk-report system-currency'
+
+## Requirements
+* Python 2.x
+* [Requests](http://python-requests.org/)
+* [PyYAML](https://pyyaml.org/)
+
+## Usage
+Specify server and username on commandline. The script will prompt for password.
+```bash
+python sat6-currency.py -n satellite.example.com -u admin
+```
+
+Load server, username and password from a [Hammer CLI configuration file](https://github.com/theforeman/hammer-cli-foreman/blob/master/doc/configuration.md). Default path is `~/.hammer/cli_config.yml`.
+```bash
+python sat6-currency.py -c [path/to/config.yml]
+```
+
+## Help Output
+```
+$ python sat6-currency.py
+usage: sat6-currency.py [-h] [-a] [-c [CONFIG]] [-n SERVER] [-u USERNAME]
+                        [-p PASSWORD] [-s SEARCH]
+
+Satellite 6 version of 'spacewalk-report system-currency'
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -a, --advanced        Use this flag if you want to divide security errata by
+                        severity. Note: this will reduce performance if this
+                        script significantly.
+  -c [CONFIG], --config [CONFIG]
+                        Hammer CLI config file (defaults to
+                        ~/.hammer/cli_config.yml
+  -n SERVER, --server SERVER
+                        Satellite server
+  -u USERNAME, --username USERNAME
+                        Username to access Satellite
+  -p PASSWORD, --password PASSWORD
+                        Password to access Satellite. The user will be asked
+                        interactively if password is not provided.
+  -s SEARCH, --search SEARCH
+                        Search string for host.( like
+                        ?search=lifecycle_environment=Test
+```

--- a/README.md
+++ b/README.md
@@ -57,11 +57,11 @@ Applicable errata are those in the Library or reference content view which are a
 | content_view | Name of the Content View server is registered to |
 | content_view_publish_date | Date on which the Content View was published |
 | lifecycle_environment | Name of the Lifecycle Environment server is registered to |
-| subscription_os_release | |
-| os_release | |
-| arch | CPU architecture |
-| subscription_status | |
-| comment | |
+| subscription_os_release | Subscribed OS repository, e.g 7Server, 7.5 |
+| os_release | OS release, e.g. RHEL 7.5 |
+| arch | CPU architecture, e.g. x86_64 |
+| subscription_status | Server's subscription status |
+| comment | Server description |
 
 ## Advanced report
 
@@ -80,11 +80,11 @@ Applicable errata are those in the Library or reference content view which are a
 | content_view | Name of the Content View server is registered to |
 | content_view_publish_date | Date on which the Content View was published |
 | lifecycle_environment | Name of the Lifecycle Environment server is registered to |
-| subscription_os_release |  |
-| os_release |  |
+| subscription_os_release | Subscribed OS repository, e.g 7Server, 7.5 |
+| os_release | OS release, e.g. RHEL 7.5 |
 | arch | CPU architecture |
-| subscription_status |  |
-| comment |  |
+| subscription_status | Server's subscription status |
+| comment | Server description |
 
 ## Library report
 
@@ -112,11 +112,11 @@ Applicable errata are those in the Library or reference content view which are a
 | content_view | Name of the Content View server is registered to |
 | content_view_publish_date | Date on which the Content View was published |
 | lifecycle_environment | Name of the Lifecycle Environment server is registered to |
-| subscription_os_release |  |
-| os_release |  |
+| subscription_os_release | Subscribed OS repository, e.g 7Server, 7.5 |
+| os_release | OS release, e.g. RHEL 7.5 |
 | arch | CPU architecture |
-| subscription_status |  |
-| comment |  |
+| subscription_status | Server's subscription status |
+| comment | Server description |
 
 ### Errata report
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+PyYAML
+requests

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -10,10 +10,14 @@ requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
 parser = argparse.ArgumentParser(description="Satellite 6 version of 'spacewalk-report system-currency'")
-parser.add_argument("-a", "--advanced", action="store_true", default=False, help="Use this flag if you want to divide security errata by severity. Note: this will reduce performance if this script significantly.")
+parser.add_argument("-a", "--advanced", action="store_true", default=False, help="Use this flag if you want to divide security errata by severity. Note: this will reduce performance of this script significantly.")
 parser.add_argument("-n", "--server", type=str.lower, required=True, help="Satellite server (defaults to localhost)", default='localhost')
 parser.add_argument("-u", "--username", type=str, required=True, help="Username to access Satellite")
 parser.add_argument("-p", "--password", type=str, required=False, help="Password to access Satellite. The user will be asked interactively if password is not provided.")
+parser.add_argument("-l", "--library", action="store_true", required=False, help="Use this flag to also report on Library Synced Content AND to divide security errata by severity. Note: this will reduce performance of this script significantly. Use with -o, -e and -c options")
+parser.add_argument("-o", "--organization", type=str, required=False, help="Organization to use when using the '-l' option")
+parser.add_argument("-c", "--contentview", type=str, required=False, default="Default Organization View", help="Content View to use using the '-l' option. Default: Default Organization View")
+parser.add_argument("-e", "--environment", type=str, required=False, default="Library", help="Environment to use with the '-l' option. Default: Library")
 
 args = parser.parse_args()
 
@@ -47,7 +51,7 @@ def get_with_json(location, json_data):
 def simple_currency():
 
     # Print headline
-    print "system_id,org_name,name,security,bug,enhancement,score,content_view,content_view_ publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
+    print "system_id,org_name,name,security,bug,enhancement,score,content_view,content_view_publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
 
     # Get all hosts (alter if you have more than 10000 hosts)
     hosts = get_with_json(api + "hosts", json.dumps({"per_page": "10000"}))["results"]
@@ -89,7 +93,7 @@ def simple_currency():
 def advanced_currency():
 
     # Print headline
-    print "system_id,org_name,name,critical,important,moderate,low,bug,enhancement,score,content_view,content_view_ publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
+    print "system_id,org_name,name,critical,important,moderate,low,bug,enhancement,score,content_view,content_view_publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
 
     # Get all hosts (if you have more than 10000 hosts, this method will take too long itme)
     hosts = get_with_json(api + "hosts", json.dumps({"per_page": "10000"}))["results"]
@@ -151,10 +155,130 @@ def advanced_currency():
             # Print result
             print str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + "," + str(errata_count_cri) + "," + str(errata_count_imp) + "," + str(errata_count_mod) + "," + str(errata_count_low) + "," + str(errata_count_bug) + "," + str(errata_count_enh) + "," + str(score) + "," + str(content_view_name) + "," + str(cv_date) + "," + str(lifecycle_environment) + "," + str(subscription_os_release) + "," + str(os_release) + "," + str(arch) + "," + str(subscription_status) + "," + str(host["comment"])
 
+def library_currency():
+
+    # Print headline
+    print "system_id,org_name,name,total_available_security,critical,important,moderate,low,bug,enhancement,score,total_applicable_security,applicable_critical,applicable_important,applicable_moderate,applicable_low,applicable_bug,applicable_enhancement,applicable_score,content_view,content_view_publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
+    # Open reports files
+    available_file = open('available.csv', 'w')
+    available_file.write('system_id,name,state,errata_id,issued,updated,severity,type,reboot_suggested,title,further_info\n')
+    applicable_file = open('applicable.csv', 'w')
+    applicable_file.write('system_id,name,state,errata_id,issued,updated,severity,type,reboot_suggested,title,further_info\n')
+
+    # Find organization
+    organization = get_with_json(katello_api + "/organizations/?Search=" + args.organization, json.dumps({"per_page": "10000"}))["results"]
+    organization_id = organization[0]["id"]
+    # print str(organization_id)
+
+    # Find lifecycle_environment
+    lifecycle_environment_compare = get_with_json(katello_api + "/organizations/" + str(organization_id) + "/environments?name=" + args.environment , json.dumps({"per_page": "10000"}))["results"]
+    lifecycle_environment_compare_id = lifecycle_environment_compare[0]["id"]
+    # print str(lifecycle_environment_compare_id)
+
+    # Find content view
+    content_view_compare = get_with_json(katello_api +"/organizations/" + str(organization_id) + "/content_views?name=" + args.contentview , json.dumps({"per_page": "10000"}))["results"]
+    content_view_compare_id = content_view_compare[0]["id"]
+    # print str(content_view_compare_id)
+
+    # Get all hosts (if you have more than 10000 hosts, this method will take too long itme)
+    hosts = get_with_json(api + "hosts", json.dumps({"per_page": "10000"}))["results"]
+
+    # Multiply factors according to "spacewalk-report system-currency"
+    factor_cri = 32
+    factor_imp = 16
+    factor_mod = 8
+    factor_low = 4
+    factor_bug = 2
+    factor_enh = 1
+
+    for host in hosts:
+
+        # Get all errata for each host
+        erratas = get_with_json(api + "hosts/" + str(host["id"]) + "/errata", json.dumps({"per_page": "10000"}))
+        applicable_erratas = get_with_json(api + "hosts/" + str(host["id"]) + "/errata?environment_id=" + str(lifecycle_environment_compare_id) + "&content_view_id=" +str(content_view_compare_id), json.dumps({"per_page": "10000"}))
+
+        # Check if host is registered with subscription-manager (unregistered hosts lack these values and are skipped)
+        if "results" in erratas:
+
+            errata_count_sec = 0
+            errata_count_cri = 0
+            errata_count_imp = 0
+            errata_count_mod = 0
+            errata_count_low = 0
+            errata_count_enh = 0
+            errata_count_bug = 0
+
+            applicable_errata_count_sec = 0
+            applicable_errata_count_cri = 0
+            applicable_errata_count_imp = 0
+            applicable_errata_count_mod = 0
+            applicable_errata_count_low = 0
+            applicable_errata_count_enh = 0
+            applicable_errata_count_bug = 0
+
+            # Check if host have any errrata at all
+            if "total" in erratas and "content_facet_attributes" in host and "subscription_facet_attributes" in host:
+                content_view_name = host["content_facet_attributes"]["content_view"]["name"]
+                content_view_id = host["content_facet_attributes"]["content_view"]["id"]
+                lifecycle_environment = host["content_facet_attributes"]["lifecycle_environment"]["name"]
+                lifecycle_environment_id = host["content_facet_attributes"]["lifecycle_environment"]["id"]
+                subscription_os_release= host["subscription_facet_attributes"]["release_version"]
+                arch = host["architecture_name"]
+                subscription_status = host["subscription_status"]
+                os_release = host["operatingsystem_name"]
+
+                content_view = get_with_json(katello_api + "/content_views/" + str(content_view_id) + "/content_view_versions?environment_id=" + str(lifecycle_environment_id), json.dumps({"per_page": "10000"}))["results"]
+
+                cv_date = content_view[0]["created_at"]
+
+                # Go through each errata that is available
+                for errata in erratas["results"]:
+
+                    # If it is a security errata, check the severity
+                    if errata["type"] == "security":
+                        errata_count_sec += 1
+                        if errata["severity"] == "Critical": errata_count_cri += 1
+                        if errata["severity"] == "Important": errata_count_imp += 1
+                        if errata["severity"] == "Moderate": errata_count_mod += 1
+                        if errata["severity"] == "Low": errata_count_low += 1
+
+                    if errata["type"] == "enhancement": errata_count_enh += 1
+                    if errata["type"] == "bugfix": errata_count_bug += 1
+
+                    available_file.write ( str(host["id"]) + "," + host["name"] + ",Available," + str(errata["errata_id"]) + "," + str(errata["issued"]) + "," + str(errata["updated"]) + "," + str(errata["severity"]) + "," + str(errata["type"]) + "," + str(errata["reboot_suggested"]) + "," + str(errata["title"]) + ",<a href=\"https://access.redhat.com/errata/" + str(errata["errata_id"]) + "\">" + str(errata["errata_id"]) + "</a>" + '\n')
+
+                # Go through each errata that is applicable (in the library)
+                for errata in applicable_erratas["results"]:
+
+                    # If it is a security errata, check the severity
+                    if errata["type"] == "security":
+                        applicable_errata_count_sec +=1
+                        if errata["severity"] == "Critical": applicable_errata_count_cri += 1
+                        if errata["severity"] == "Important": applicable_errata_count_imp += 1
+                        if errata["severity"] == "Moderate": applicable_errata_count_mod += 1
+                        if errata["severity"] == "Low": applicable_errata_count_low += 1
+
+                    if errata["type"] == "enhancement": applicable_errata_count_enh += 1
+                    if errata["type"] == "bugfix": applicable_errata_count_bug += 1
+
+                    # print str(host["id"]) + "," + host["name"] + ",Applicable," + str(errata["errata_id"]) + "," + str(errata["issued"]) + "," + str(errata["updated"]) + "," + str(errata["severity"]) + "," + str(errata["type"]) + "," + str(errata["reboot_suggested"]) + "," + str(errata["updated"]) + "," + str(errata["title"]) + ",<a href=\"https://access.redhat.com/errata/" + str(errata["errata_id"]) + "\">" + str(errata["errata_id"]) + "</a>"
+                    applicable_file.write ( str(host["id"]) + "," + host["name"] + ",Applicable," + str(errata["errata_id"]) + "," + str(errata["issued"]) + "," + str(errata["updated"]) + "," + str(errata["severity"]) + "," + str(errata["type"]) + "," + str(errata["reboot_suggested"]) + "," + str(errata["title"]) + ",<a href=\"https://access.redhat.com/errata/" + str(errata["errata_id"]) + "\">" + str(errata["errata_id"]) + "</a>" + '\n')
+
+            # Calculate weighted score
+            score = factor_cri * errata_count_cri + factor_imp * errata_count_imp + factor_mod * errata_count_mod + factor_low * errata_count_low + factor_bug * errata_count_bug + factor_enh * errata_count_enh
+            applicable_score = factor_cri * applicable_errata_count_cri + factor_imp * applicable_errata_count_imp + factor_mod * applicable_errata_count_mod + factor_low * applicable_errata_count_low + factor_bug * applicable_errata_count_bug + factor_enh * applicable_errata_count_enh
+
+            # Print result
+            print str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + "," + str(errata_count_sec) + "," + str(errata_count_cri) + "," + str(errata_count_imp) + "," + str(errata_count_mod) + "," + str(errata_count_low) + "," + str(errata_count_bug) + "," + str(errata_count_enh) + "," + str(score) + ","  + str(applicable_errata_count_sec) + "," + str(applicable_errata_count_cri) + "," + str(applicable_errata_count_imp) + "," + str(applicable_errata_count_mod) + "," + str(applicable_errata_count_low) + "," + str(applicable_errata_count_bug) + "," + str(applicable_errata_count_enh) + "," + str(applicable_score) + "," + str(content_view_name) + "," + str(cv_date) + "," + str(lifecycle_environment) + "," + str(subscription_os_release) + "," + str(os_release) + "," + str(arch) + "," + str(subscription_status) + "," + str(host["comment"])
+
+    available_file.closed
+    applicable_file.closed
 
 if __name__ == "__main__":
 
     if args.advanced:
         advanced_currency()
+    if args.library:
+        library_currency()
     else:
         simple_currency()

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -77,7 +77,11 @@ def get_with_json(location, json_data):
         print sys.argv[0] + " Couldn't connect to the API, check connection or url"
         print e
         sys.exit(1)
-    return result.json()
+    if result.ok:
+        return result.json()
+    else:
+        print sys.argv[0] + " Error connecting to '" + location + "'. HTTP Status: " + str(result.status_code)
+        sys.exit(1)
 
 def simple_currency():
 

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -11,14 +11,47 @@ from requests.packages.urllib3.exceptions import InsecureRequestWarning
 requests.packages.urllib3.disable_warnings(InsecureRequestWarning)
 
 
-parser = argparse.ArgumentParser(description="Satellite 6 version of 'spacewalk-report system-currency'")
-parser.add_argument("-a", "--advanced", action="store_true", default=False, help="Use this flag if you want to divide security errata by severity. Note: this will reduce performance if this script significantly.")
-parser.add_argument("-c", "--config", type=argparse.FileType(mode='r'), nargs='?', help="Hammer CLI config file (defaults to ~/.hammer/cli_config.yml", const=os.path.expanduser('~/.hammer/cli_config.yml'))
-parser.add_argument("-n", "--server", type=str.lower, help="Satellite server")
-parser.add_argument("-u", "--username", type=str, help="Username to access Satellite")
-parser.add_argument("-p", "--password", type=str, help="Password to access Satellite. The user will be asked interactively if password is not provided.")
-parser.add_argument("-s", "--search", type=str, required=False, help="Search string for host.( like ?search=lifecycle_environment=Test", default=(''))
-
+parser = argparse.ArgumentParser(
+    description="Satellite 6 version of 'spacewalk-report system-currency'"
+)
+parser.add_argument(
+    "-a", "--advanced",
+    action="store_true",
+    default=False,
+    help="Use this flag if you want to divide security errata by severity."
+    " Note: this will reduce performance if this script significantly."
+)
+parser.add_argument(
+    "-c", "--config",
+    type=argparse.FileType(mode='r'),
+    nargs='?',
+    help="Hammer CLI config file (defaults to ~/.hammer/cli_config.yml",
+    const=os.path.expanduser('~/.hammer/cli_config.yml')
+)
+parser.add_argument(
+    "-n", "--server",
+    type=str.lower,
+    help="Satellite server"
+)
+parser.add_argument(
+    "-u", "--username",
+    type=str,
+    help="Username to access Satellite"
+)
+parser.add_argument(
+    "-p", "--password",
+    type=str,
+    help="Password to access Satellite."
+    " The user will be asked interactively if password is not provided."
+)
+parser.add_argument(
+    "-s", "--search",
+    type=str,
+    required=False,
+    help="Search string for host."
+    "( like ?search=lifecycle_environment=Test",
+    default=('')
+)
 args = parser.parse_args()
 
 server = args.server
@@ -33,15 +66,24 @@ if args.config is not None:
     # Values specified on the commandline take precendence over config file
     key = ':foreman'
     try:
-        server = config[key][':host'] if args.server is None else args.server
+        if args.server is None:
+            server = config[key][':host']
+        else:
+            server = args.server
     except(KeyError):
         pass
     try:
-        username = config[key][':username'] if args.username is None else args.username
+        if args.username is None:
+            username = config[key][':username']
+        else:
+            username = args.username
     except(KeyError):
         pass
     try:
-        password = config[key][':password'] if args.password is None else args.password
+        if args.password is None:
+            password = config[key][':password']
+        else:
+            ppassword = args.password
     except(KeyError):
         pass
 
@@ -60,32 +102,43 @@ else:
 api = url + "/api/"
 katello_api = url + "/katello/api/v2"
 post_headers = {'content-type': 'application/json'}
-ssl_verify=True
+ssl_verify = True
+
 
 def get_with_json(location, json_data):
     """
     Performs a GET and passes the data to the url location
     """
     try:
-        result = requests.get(location,
-                            data=json_data,
-                            auth=(username, password),
-                            verify=ssl_verify,
-                            headers=post_headers)
+        result = requests.get(
+            location,
+            data=json_data,
+            auth=(username, password),
+            verify=ssl_verify,
+            headers=post_headers
+        )
 
     except requests.ConnectionError, e:
-        print sys.argv[0] + " Couldn't connect to the API, check connection or url"
-        print e
+        print("{} Couldn't connect to the API,"
+              " check connection or url".format(sys.argv[0]))
+        print(e)
         sys.exit(1)
     return result.json()
+
 
 def simple_currency():
 
     # Print headline
-    print "system_id,org_name,name,security,bug,enhancement,score,content_view,content_view_ publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
+    print("system_id,org_name,name,security,bug,enhancement,score,"
+          "content_view,content_view_ publish_date,lifecycle_environment,"
+          "subscription_os_release,os_release,arch,subscription_status,"
+          "comment")
 
     # Get all hosts (alter if you have more than 10000 hosts)
-    hosts = get_with_json(api + "hosts" + args.search, json.dumps({"per_page": "10000"}))["results"]
+    hosts = get_with_json(
+        "{}hosts{}".format(api, args.search),
+        json.dumps({"per_page": "10000"})
+    )["results"]
 
     # Multiply factors
     factor_sec = 8
@@ -93,41 +146,92 @@ def simple_currency():
     factor_enh = 1
 
     for host in hosts:
-        # Check if host is registered with subscription-manager (unregistered hosts lack these values and are skipped)
-        if "content_facet_attributes" in host and host["content_facet_attributes"]["errata_counts"]:
-
+        # Check if host is registered with subscription-manager
+        # (unregistered hosts lack these values and are skipped)
+        if (
+                "content_facet_attributes" in host and
+                host["content_facet_attributes"]["errata_counts"]
+        ):
             # Get each number of different kinds of erratas
-            errata_count_sec = host["content_facet_attributes"]["errata_counts"]["security"]
-            errata_count_bug = host["content_facet_attributes"]["errata_counts"]["bugfix"]
-            errata_count_enh = host["content_facet_attributes"]["errata_counts"]["enhancement"]
-            content_view_name = host["content_facet_attributes"]["content_view"]["name"]
-            content_view_id = host["content_facet_attributes"]["content_view"]["id"]
-            lifecycle_environment = host["content_facet_attributes"]["lifecycle_environment"]["name"]
-            lifecycle_environment_id = host["content_facet_attributes"]["lifecycle_environment"]["id"]
-            subscription_os_release= host["subscription_facet_attributes"]["release_version"]
+            errata_count_sec = host[
+                "content_facet_attributes"]["errata_counts"]["security"]
+            errata_count_bug = host[
+                "content_facet_attributes"]["errata_counts"]["bugfix"]
+            errata_count_enh = host[
+                "content_facet_attributes"]["errata_counts"]["enhancement"]
+            content_view_name = host[
+                "content_facet_attributes"]["content_view"]["name"]
+            content_view_id = host[
+                "content_facet_attributes"]["content_view"]["id"]
+            lifecycle_environment = host[
+                "content_facet_attributes"]["lifecycle_environment"]["name"]
+            lifecycle_environment_id = host[
+                "content_facet_attributes"]["lifecycle_environment"]["id"]
+            subscription_os_release = host[
+                "subscription_facet_attributes"]["release_version"]
             arch = host["architecture_name"]
             subscription_status = host["subscription_status"]
             os_release = host["operatingsystem_name"]
 
-            content_view = get_with_json(katello_api + "/content_views/" + str(content_view_id) + "/content_view_versions?environment_id=" + str(lifecycle_environment_id), json.dumps({"per_page": "10000"}))["results"]
+            content_view = get_with_json(
+                "{}/content_views/{}/content_view_versions?"
+                "environment_id={}".format(
+                    katello_api,
+                    str(content_view_id),
+                    str(lifecycle_environment_id)
+                ),
+                json.dumps({"per_page": "10000"})
+            )["results"]
 
             cv_date = content_view[0]["created_at"]
-            if errata_count_sec is None or errata_count_bug is None or errata_count_enh is None:
+            if (
+                    errata_count_sec is None or
+                    errata_count_bug is None or
+                    errata_count_enh is None
+            ):
                 score = 0
             else:
-            # Calculate weighted score
-                score = errata_count_sec * factor_sec + errata_count_bug * factor_bug + errata_count_enh * factor_enh
+                # Calculate weighted score
+                score = (errata_count_sec * factor_sec +
+                         errata_count_bug * factor_bug +
+                         errata_count_enh * factor_enh)
 
             # Print result
-            print str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + "," + str(errata_count_sec) + "," + str(errata_count_bug) + "," + str(errata_count_enh) + "," + str(score) + "," + str(content_view_name) + "," + str(cv_date) + "," + str(lifecycle_environment) + "," + str(subscription_os_release) + "," + str(os_release) + "," + str(arch) + "," + str(subscription_status) + "," + str(host["comment"])
+            print(
+                ','.join(str(x) for x in [
+                    host["id"],
+                    host["organization_name"],
+                    host["name"],
+                    errata_count_sec,
+                    errata_count_bug,
+                    errata_count_enh,
+                    score,
+                    content_view_name,
+                    cv_date,
+                    lifecycle_environment,
+                    subscription_os_release,
+                    os_release,
+                    arch,
+                    subscription_status,
+                    host["comment"],
+                ]
+                         )
+            )
+
 
 def advanced_currency():
 
     # Print headline
-    print "system_id,org_name,name,critical,important,moderate,low,bug,enhancement,score,content_view,content_view_ publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
+    print("system_id,org_name,name,critical,important,moderate,low,bug,"
+          "enhancement,score,content_view,content_view_ publish_date,"
+          "lifecycle_environment,subscription_os_release,os_release,arch,"
+          "subscription_status,comment")
 
-    # Get all hosts (if you have more than 10000 hosts, this method will take too long itme)
-    hosts = get_with_json(api + "hosts" + args.search, json.dumps({"per_page": "10000"}))["results"]
+    # Get all hosts (for more than 10000 hosts, this will take a long time)
+    hosts = get_with_json(
+        "{}hosts{}".format(api, args.search),
+        json.dumps({"per_page": "10000"})
+    )["results"]
 
     # Multiply factors according to "spacewalk-report system-currency"
     factor_cri = 32
@@ -140,9 +244,13 @@ def advanced_currency():
     for host in hosts:
 
         # Get all errata for each host
-        erratas = get_with_json(api + "hosts/" + str(host["id"]) + "/errata", json.dumps({"per_page": "10000"}))
+        erratas = get_with_json(
+            "{}hosts/{}/errata".format(api, str(host["id"])),
+            json.dumps({"per_page": "10000"})
+        )
 
-        # Check if host is registered with subscription-manager (unregistered hosts lack these values and are skipped)
+        # Check if host is registered with subscription-manager
+        # (unregistered hosts lack these values and are skipped)
         if "results" in erratas:
 
             errata_count_cri = 0
@@ -153,17 +261,35 @@ def advanced_currency():
             errata_count_bug = 0
 
             # Check if host have any errrata at all
-            if "total" in erratas and "content_facet_attributes" in host and "subscription_facet_attributes" in host:
-                content_view_name = host["content_facet_attributes"]["content_view"]["name"]
-                content_view_id = host["content_facet_attributes"]["content_view"]["id"]
-                lifecycle_environment = host["content_facet_attributes"]["lifecycle_environment"]["name"]
-                lifecycle_environment_id = host["content_facet_attributes"]["lifecycle_environment"]["id"]
-                subscription_os_release= host["subscription_facet_attributes"]["release_version"]
+            if(
+                    "total" in erratas and
+                    "content_facet_attributes" in host and
+                    "subscription_facet_attributes" in host
+            ):
+                content_view_name = host[
+                    "content_facet_attributes"]["content_view"]["name"]
+                content_view_id = host[
+                    "content_facet_attributes"]["content_view"]["id"]
+                lifecycle_environment = host[
+                    "content_facet_attributes"][
+                        "lifecycle_environment"]["name"]
+                lifecycle_environment_id = host[
+                    "content_facet_attributes"]["lifecycle_environment"]["id"]
+                subscription_os_release = host[
+                    "subscription_facet_attributes"]["release_version"]
                 arch = host["architecture_name"]
                 subscription_status = host["subscription_status"]
                 os_release = host["operatingsystem_name"]
 
-                content_view = get_with_json(katello_api + "/content_views/" + str(content_view_id) + "/content_view_versions?environment_id=" + str(lifecycle_environment_id), json.dumps({"per_page": "10000"}))["results"]
+                content_view = get_with_json(
+                    "{}/content_views/{}/content_view_versions?"
+                    "environment_id={}".format(
+                        katello_api,
+                        str(content_view_id),
+                        str(lifecycle_environment_id)
+                    ),
+                    json.dumps({"per_page": "10000"})
+                )["results"]
 
                 cv_date = content_view[0]["created_at"]
 
@@ -172,19 +298,52 @@ def advanced_currency():
 
                     # If it is a security errata, check the severity
                     if errata["type"] == "security":
-                        if errata["severity"] == "Critical": errata_count_cri += 1
-                        if errata["severity"] == "Important": errata_count_imp += 1
-                        if errata["severity"] == "Moderate": errata_count_mod += 1
-                        if errata["severity"] == "Low": errata_count_low += 1
+                        if errata["severity"] == "Critical":
+                            errata_count_cri += 1
+                        if errata["severity"] == "Important":
+                            errata_count_imp += 1
+                        if errata["severity"] == "Moderate":
+                            errata_count_mod += 1
+                        if errata["severity"] == "Low":
+                            errata_count_low += 1
 
-                    if errata["type"] == "enhancement": errata_count_enh += 1
-                    if errata["type"] == "bugfix": errata_count_bug += 1
+                    if errata["type"] == "enhancement":
+                        errata_count_enh += 1
+                    if errata["type"] == "bugfix":
+                        errata_count_bug += 1
 
             # Calculate weighted score
-            score = factor_cri * errata_count_cri + factor_imp * errata_count_imp + factor_mod * errata_count_mod + factor_low * errata_count_low + factor_bug * errata_count_bug + factor_enh * errata_count_enh
+            score = (factor_cri * errata_count_cri +
+                     factor_imp * errata_count_imp +
+                     factor_mod * errata_count_mod +
+                     factor_low * errata_count_low +
+                     factor_bug * errata_count_bug +
+                     factor_enh * errata_count_enh)
 
             # Print result
-            print str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + "," + str(errata_count_cri) + "," + str(errata_count_imp) + "," + str(errata_count_mod) + "," + str(errata_count_low) + "," + str(errata_count_bug) + "," + str(errata_count_enh) + "," + str(score) + "," + str(content_view_name) + "," + str(cv_date) + "," + str(lifecycle_environment) + "," + str(subscription_os_release) + "," + str(os_release) + "," + str(arch) + "," + str(subscription_status) + "," + str(host["comment"])
+            print(
+                ','.join(str(x) for x in [
+                    host["id"],
+                    host["organization_name"],
+                    host["name"],
+                    errata_count_cri,
+                    errata_count_imp,
+                    errata_count_mod,
+                    errata_count_low,
+                    errata_count_bug,
+                    errata_count_enh,
+                    score,
+                    content_view_name,
+                    cv_date,
+                    lifecycle_environment,
+                    subscription_os_release,
+                    os_release,
+                    arch,
+                    subscription_status,
+                    host["comment"],
+                ]
+                         )
+            )
 
 
 if __name__ == "__main__":

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -227,9 +227,11 @@ def simple_currency():
                 score = 0
             else:
                 # Calculate weighted score
-                score = (errata_count_sec * factor_sec +
-                         errata_count_bug * factor_bug +
-                         errata_count_enh * factor_enh)
+                score = (
+                    errata_count_sec * factor_sec +
+                    errata_count_bug * factor_bug +
+                    errata_count_enh * factor_enh
+                )
 
             # Print result
             print(
@@ -348,12 +350,14 @@ def advanced_currency():
                         errata_count_bug += 1
 
             # Calculate weighted score
-            score = (factor_cri * errata_count_cri +
-                     factor_imp * errata_count_imp +
-                     factor_mod * errata_count_mod +
-                     factor_low * errata_count_low +
-                     factor_bug * errata_count_bug +
-                     factor_enh * errata_count_enh)
+            score = (
+                factor_cri * errata_count_cri +
+                factor_imp * errata_count_imp +
+                factor_mod * errata_count_mod +
+                factor_low * errata_count_low +
+                factor_bug * errata_count_bug +
+                factor_enh * errata_count_enh
+            )
 
             # Print result
             print(
@@ -388,17 +392,29 @@ def library_currency():
         sys.exit(1)
 
     # Print headline
-    print "system_id,org_name,name,total_available_security,critical,important,moderate,low,bug,enhancement,score,total_applicable_security,applicable_critical,applicable_important,applicable_moderate,applicable_low,applicable_bug,applicable_enhancement,applicable_score,content_view,content_view_publish_date,lifecycle_environment,subscription_os_release,os_release,arch,subscription_status,comment"
+    print(
+        "system_id,org_name,name,total_available_security,critical,"
+        "important,moderate,low,bug,enhancement,score,"
+        "total_applicable_security,applicable_critical,applicable_important,"
+        "applicable_moderate,applicable_low,applicable_bug,"
+        "applicable_enhancement,applicable_score,content_view,"
+        "content_view_publish_date,lifecycle_environment,"
+        "subscription_os_release,os_release,arch,subscription_status,comment"
+          )
     # Open reports files
     available_file = open('available_errata.csv', 'w')
-    available_file.write('system_id,org_name,name,state,errata_id,issued,updated,severity,type,reboot_suggested,title,further_info\n')
+    available_file.write(
+        "system_id,org_name,name,state,errata_id,issued,"
+        "updated,severity,type,reboot_suggested,title,further_info\n"
+    )
     applicable_file = open('applicable_errata.csv', 'w')
-    applicable_file.write('system_id,org_name,name,state,errata_id,issued,updated,severity,type,reboot_suggested,title,further_info\n')
+    applicable_file.write(
+        "system_id,org_name,name,state,errata_id,issued,"
+        "updated,severity,type,reboot_suggested,title,further_info\n"
+    )
 
     # Red Hat errata URL
     RH_URL = "https://access.redhat.com/errata/"
-    # Fedora EPEL errata URL
-    EPEL_URL = "https://bodhi.fedoraproject.org/updates"
 
     # Find organization
     organization = get_with_json(
@@ -409,17 +425,28 @@ def library_currency():
     # print str(organization_id)
 
     # Find lifecycle_environment
-    lifecycle_environment_compare = get_with_json(katello_api + "/organizations/" + str(organization_id) + "/environments?name=" + args.environment, json.dumps({"per_page": "10000"}))["results"]
+    lifecycle_environment_compare = get_with_json(
+        "{}/organizations/{}/environments?name={}".format(
+            katello_api, str(organization_id), args.environment),
+        json.dumps({"per_page": "10000"})
+    )["results"]
     lifecycle_environment_compare_id = lifecycle_environment_compare[0]["id"]
     # print str(lifecycle_environment_compare_id)
 
     # Find content view
-    content_view_compare = get_with_json(katello_api + "/organizations/" + str(organization_id) + "/content_views?name=" + args.contentview, json.dumps({"per_page": "10000"}))["results"]
+    content_view_compare = get_with_json(
+        "{}/organizations/{}/content_views?name={}".format(
+            katello_api, str(organization_id), args.contentview),
+        json.dumps({"per_page": "10000"})
+    )["results"]
     content_view_compare_id = content_view_compare[0]["id"]
     # print str(content_view_compare_id)
 
-    # Get all hosts (if you have more than 10000 hosts, this method will take too long itme)
-    hosts = get_with_json(api + "hosts", json.dumps({"per_page": "10000"}))["results"]
+    # Get all hosts (for more than 10000 hosts, this will take a long time)
+    hosts = get_with_json(
+        "{}hosts{}".format(api, args.search),
+        json.dumps({"per_page": "10000"})
+    )["results"]
 
     # Multiply factors according to "spacewalk-report system-currency"
     factor_cri = 32
@@ -432,10 +459,22 @@ def library_currency():
     for host in hosts:
 
         # Get all errata for each host
-        erratas = get_with_json(api + "hosts/" + str(host["id"]) + "/errata", json.dumps({"per_page": "10000"}))
-        applicable_erratas = get_with_json(api + "hosts/" + str(host["id"]) + "/errata?environment_id=" + str(lifecycle_environment_compare_id) + "&content_view_id=" + str(content_view_compare_id), json.dumps({"per_page": "10000"}))
+        erratas = get_with_json(
+            "{}hosts/{}/errata".format(api, str(host["id"])),
+            json.dumps({"per_page": "10000"})
+        )
+        applicable_erratas = get_with_json(
+            "{}hosts/{}/errata?environment_id={}&content_view_id={}".format(
+                api,
+                str(host["id"]),
+                str(lifecycle_environment_compare_id),
+                str(content_view_compare_id)
+            ),
+            json.dumps({"per_page": "10000"})
+        )
 
-        # Check if host is registered with subscription-manager (unregistered hosts lack these values and are skipped)
+        # Check if host is registered with subscription-manager
+        # (unregistered hosts lack these values and are skipped)
         if "results" in erratas:
 
             errata_count_sec = 0
@@ -455,17 +494,35 @@ def library_currency():
             applicable_errata_count_bug = 0
 
             # Check if host have any errrata at all
-            if "total" in erratas and "content_facet_attributes" in host and "subscription_facet_attributes" in host:
-                content_view_name = host["content_facet_attributes"]["content_view"]["name"]
-                content_view_id = host["content_facet_attributes"]["content_view"]["id"]
-                lifecycle_environment = host["content_facet_attributes"]["lifecycle_environment"]["name"]
-                lifecycle_environment_id = host["content_facet_attributes"]["lifecycle_environment"]["id"]
-                subscription_os_release= host["subscription_facet_attributes"]["release_version"]
+            if (
+                    "total" in erratas and
+                    "content_facet_attributes" in host and
+                    "subscription_facet_attributes" in host
+            ):
+                content_view_name = host[
+                    "content_facet_attributes"]["content_view"]["name"]
+                content_view_id = host[
+                    "content_facet_attributes"]["content_view"]["id"]
+                lifecycle_environment = host[
+                    "content_facet_attributes"][
+                        "lifecycle_environment"]["name"]
+                lifecycle_environment_id = host[
+                    "content_facet_attributes"]["lifecycle_environment"]["id"]
+                subscription_os_release = host[
+                    "subscription_facet_attributes"]["release_version"]
                 arch = host["architecture_name"]
                 subscription_status = host["subscription_status"]
                 os_release = host["operatingsystem_name"]
 
-                content_view = get_with_json(katello_api + "/content_views/" + str(content_view_id) + "/content_view_versions?environment_id=" + str(lifecycle_environment_id), json.dumps({"per_page": "10000"}))["results"]
+                content_view = get_with_json(
+                    "{}/content_views/{}/content_view_versions?"
+                    "environment_id={}".format(
+                        katello_api,
+                        str(content_view_id),
+                        str(lifecycle_environment_id)
+                    ),
+                    json.dumps({"per_page": "10000"})
+                )["results"]
 
                 cv_date = content_view[0]["created_at"]
 
@@ -475,48 +532,137 @@ def library_currency():
                     # If it is a security errata, check the severity
                     if errata["type"] == "security":
                         errata_count_sec += 1
-                        if errata["severity"] == "Critical": errata_count_cri += 1
-                        if errata["severity"] == "Important": errata_count_imp += 1
-                        if errata["severity"] == "Moderate": errata_count_mod += 1
-                        if errata["severity"] == "Low": errata_count_low += 1
+                        if errata["severity"] == "Critical":
+                            errata_count_cri += 1
+                        if errata["severity"] == "Important":
+                            errata_count_imp += 1
+                        if errata["severity"] == "Moderate":
+                            errata_count_mod += 1
+                        if errata["severity"] == "Low":
+                            errata_count_low += 1
 
-                    if errata["type"] == "enhancement": errata_count_enh += 1
-                    if errata["type"] == "bugfix": errata_count_bug += 1
+                    if errata["type"] == "enhancement":
+                        errata_count_enh += 1
+                    if errata["type"] == "bugfix":
+                        errata_count_bug += 1
 
                     # Delete any commas from the errata title
                     # eg: https://access.redhat.com/errata/RHSA-2017:0817
                     errata["title"] = errata["title"].replace(',', '')
-                    available_file.write ( str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + ",Available," + str(errata["errata_id"]) + "," + str(errata["issued"]) + "," + str(errata["updated"]) + "," + str(errata["severity"]) + "," + str(errata["type"]) + "," + str(errata["reboot_suggested"]) + "," + str(errata["title"]) + "," + str(RH_URL) + str(errata["errata_id"]) + '\n')
+                    available_file.write(
+                        ','.join(str(x) for x in [
+                            str(host["id"]),
+                            str(host["organization_name"]),
+                            host["name"],
+                            "Available",
+                            str(errata["errata_id"]),
+                            str(errata["issued"]),
+                            str(errata["updated"]),
+                            str(errata["severity"]),
+                            str(errata["type"]),
+                            str(errata["reboot_suggested"]),
+                            str(errata["title"]),
+                            "{}{}\n".format(RH_URL, str(errata["errata_id"])),
+                        ]
+                                 )
+                    )
 
                 # Go through each errata that is applicable (in the library)
                 for errata in applicable_erratas["results"]:
 
                     # If it is a security errata, check the severity
                     if errata["type"] == "security":
-                        applicable_errata_count_sec +=1
-                        if errata["severity"] == "Critical": applicable_errata_count_cri += 1
-                        if errata["severity"] == "Important": applicable_errata_count_imp += 1
-                        if errata["severity"] == "Moderate": applicable_errata_count_mod += 1
-                        if errata["severity"] == "Low": applicable_errata_count_low += 1
+                        applicable_errata_count_sec += 1
+                        if errata["severity"] == "Critical":
+                            applicable_errata_count_cri += 1
+                        if errata["severity"] == "Important":
+                            applicable_errata_count_imp += 1
+                        if errata["severity"] == "Moderate":
+                            applicable_errata_count_mod += 1
+                        if errata["severity"] == "Low":
+                            applicable_errata_count_low += 1
 
-                    if errata["type"] == "enhancement": applicable_errata_count_enh += 1
-                    if errata["type"] == "bugfix": applicable_errata_count_bug += 1
+                    if errata["type"] == "enhancement":
+                        applicable_errata_count_enh += 1
+                    if errata["type"] == "bugfix":
+                        applicable_errata_count_bug += 1
 
                     # Delete any commas from the errata title
                     # eg: https://access.redhat.com/errata/RHSA-2017:0817
                     errata["title"] = errata["title"].replace(',', '')
-                    # print str(host["id"]) + "," + host["name"] + ",Applicable," + str(errata["errata_id"]) + "," + str(errata["issued"]) + "," + str(errata["updated"]) + "," + str(errata["severity"]) + "," + str(errata["type"]) + "," + str(errata["reboot_suggested"]) + "," + str(errata["updated"]) + "," + str(errata["title"]) + ",<a href=\"https://access.redhat.com/errata/" + str(errata["errata_id"]) + "\">" + str(errata["errata_id"]) + "</a>"
-                    applicable_file.write ( str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + ",Applicable," + str(errata["errata_id"]) + "," + str(errata["issued"]) + "," + str(errata["updated"]) + "," + str(errata["severity"]) + "," + str(errata["type"]) + "," + str(errata["reboot_suggested"]) + "," + str(errata["title"])  + "," + str(RH_URL) + str(errata["errata_id"]) + '\n')
+                    available_file.write(
+                        ','.join(str(x) for x in [
+                            str(host["id"]),
+                            str(host["organization_name"]),
+                            host["name"],
+                            "Applicable",
+                            str(errata["errata_id"]),
+                            str(errata["issued"]),
+                            str(errata["updated"]),
+                            str(errata["severity"]),
+                            str(errata["type"]),
+                            str(errata["reboot_suggested"]),
+                            str(errata["title"]),
+                            "{}{}\n".format(RH_URL, str(errata["errata_id"])),
+                        ]
+                                 )
+                    )
 
             # Calculate weighted score
-            score = factor_cri * errata_count_cri + factor_imp * errata_count_imp + factor_mod * errata_count_mod + factor_low * errata_count_low + factor_bug * errata_count_bug + factor_enh * errata_count_enh
-            applicable_score = factor_cri * applicable_errata_count_cri + factor_imp * applicable_errata_count_imp + factor_mod * applicable_errata_count_mod + factor_low * applicable_errata_count_low + factor_bug * applicable_errata_count_bug + factor_enh * applicable_errata_count_enh
+            score = (
+                factor_cri * errata_count_cri +
+                factor_imp * errata_count_imp +
+                factor_mod * errata_count_mod +
+                factor_low * errata_count_low +
+                factor_bug * errata_count_bug +
+                factor_enh * errata_count_enh
+            )
+            applicable_score = (
+                factor_cri * applicable_errata_count_cri +
+                factor_imp * applicable_errata_count_imp +
+                factor_mod * applicable_errata_count_mod +
+                factor_low * applicable_errata_count_low +
+                factor_bug * applicable_errata_count_bug +
+                factor_enh * applicable_errata_count_enh
+            )
 
             # Print result
-            print str(host["id"]) + "," + str(host["organization_name"]) + "," + host["name"] + "," + str(errata_count_sec) + "," + str(errata_count_cri) + "," + str(errata_count_imp) + "," + str(errata_count_mod) + "," + str(errata_count_low) + "," + str(errata_count_bug) + "," + str(errata_count_enh) + "," + str(score) + ","  + str(applicable_errata_count_sec) + "," + str(applicable_errata_count_cri) + "," + str(applicable_errata_count_imp) + "," + str(applicable_errata_count_mod) + "," + str(applicable_errata_count_low) + "," + str(applicable_errata_count_bug) + "," + str(applicable_errata_count_enh) + "," + str(applicable_score) + "," + str(content_view_name) + "," + str(cv_date) + "," + str(lifecycle_environment) + "," + str(subscription_os_release) + "," + str(os_release) + "," + str(arch) + "," + str(subscription_status) + "," + str(host["comment"])
+            print(
+                ','.join(str(x) for x in [
+                    str(host["id"]),
+                    str(host["organization_name"]),
+                    host["name"],
+                    str(errata_count_sec),
+                    str(errata_count_cri),
+                    str(errata_count_imp),
+                    str(errata_count_mod),
+                    str(errata_count_low),
+                    str(errata_count_bug),
+                    str(errata_count_enh),
+                    str(score),
+                    str(applicable_errata_count_sec),
+                    str(applicable_errata_count_cri),
+                    str(applicable_errata_count_imp),
+                    str(applicable_errata_count_mod),
+                    str(applicable_errata_count_low),
+                    str(applicable_errata_count_bug),
+                    str(applicable_errata_count_enh),
+                    str(applicable_score),
+                    str(content_view_name),
+                    str(cv_date),
+                    str(lifecycle_environment),
+                    str(subscription_os_release),
+                    str(os_release),
+                    str(arch),
+                    str(subscription_status),
+                    str(host["comment"]),
+                ]
+                         )
+            )
 
     available_file.closed
     applicable_file.closed
+
 
 if __name__ == "__main__":
 

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -164,10 +164,26 @@ def get_with_json(location, json_data):
 def simple_currency():
 
     # Print headline
-    print("system_id,org_name,name,security,bug,enhancement,score,"
-          "content_view,content_view_ publish_date,lifecycle_environment,"
-          "subscription_os_release,os_release,arch,subscription_status,"
-          "comment")
+    print(
+        ','.join(str(x) for x in [
+            "system_id",
+            "org_name",
+            "name",
+            "security",
+            "bug",
+            "enhancement",
+            "score",
+            "content_view",
+            "content_view_publish_date",
+            "lifecycle_environment",
+            "subscription_os_release",
+            "os_release",
+            "arch",
+            "subscription_status",
+            "comment"
+        ]
+                 )
+    )
 
     # Get all hosts (alter if you have more than 10000 hosts)
     hosts = get_with_json(
@@ -259,10 +275,29 @@ def simple_currency():
 def advanced_currency():
 
     # Print headline
-    print("system_id,org_name,name,critical,important,moderate,low,bug,"
-          "enhancement,score,content_view,content_view_ publish_date,"
-          "lifecycle_environment,subscription_os_release,os_release,arch,"
-          "subscription_status,comment")
+    print(
+        ','.join(str(x) for x in [
+            "system_id",
+            "org_name",
+            "name",
+            "critical",
+            "important",
+            "moderate",
+            "low",
+            "bug",
+            "enhancement",
+            "score",
+            "content_view",
+            "content_view_publish_date",
+            "lifecycle_environment",
+            "subscription_os_release",
+            "os_release",
+            "arch",
+            "subscription_status",
+            "comment"
+        ]
+                 )
+    )
 
     # Get all hosts (for more than 10000 hosts, this will take a long time)
     hosts = get_with_json(
@@ -393,14 +428,37 @@ def library_currency():
 
     # Print headline
     print(
-        "system_id,org_name,name,total_available_security,critical,"
-        "important,moderate,low,bug,enhancement,score,"
-        "total_applicable_security,applicable_critical,applicable_important,"
-        "applicable_moderate,applicable_low,applicable_bug,"
-        "applicable_enhancement,applicable_score,content_view,"
-        "content_view_publish_date,lifecycle_environment,"
-        "subscription_os_release,os_release,arch,subscription_status,comment"
-          )
+        ','.join(str(x) for x in [
+            "system_id",
+            "org_name",
+            "name",
+            "critical",
+            "important",
+            "moderate",
+            "low",
+            "bug",
+            "enhancement",
+            "score",
+            "total_applicable_security",
+            "applicable_critical",
+            "applicable_important",
+            "applicable_moderate",
+            "applicable_low",
+            "applicable_bug",
+            "applicable_enhancement",
+            "applicable_score",
+            "content_view",
+            "content_view_publish_date",
+            "lifecycle_environment",
+            "subscription_os_release",
+            "os_release",
+            "arch",
+            "subscription_status",
+            "comment",
+        ]
+                 )
+    )
+
     # Open reports files
     available_file = open('available_errata.csv', 'w')
     available_file.write(

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -432,6 +432,7 @@ def library_currency():
             "system_id",
             "org_name",
             "name",
+            "total_available_security",
             "critical",
             "important",
             "moderate",

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -221,7 +221,7 @@ def simple_currency():
             subscription_os_release = host[
                 "subscription_facet_attributes"]["release_version"]
             arch = host["architecture_name"]
-            subscription_status = host["subscription_status"]
+            subscription_status = host["subscription_status_label"]
             os_release = host["operatingsystem_name"]
 
             content_view = get_with_json(
@@ -350,7 +350,7 @@ def advanced_currency():
                 subscription_os_release = host[
                     "subscription_facet_attributes"]["release_version"]
                 arch = host["architecture_name"]
-                subscription_status = host["subscription_status"]
+                subscription_status = host["subscription_status_label"]
                 os_release = host["operatingsystem_name"]
 
                 content_view = get_with_json(
@@ -570,7 +570,7 @@ def library_currency():
                 subscription_os_release = host[
                     "subscription_facet_attributes"]["release_version"]
                 arch = host["architecture_name"]
-                subscription_status = host["subscription_status"]
+                subscription_status = host["subscription_status_label"]
                 os_release = host["operatingsystem_name"]
 
                 content_view = get_with_json(

--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -727,7 +727,9 @@ if __name__ == "__main__":
 
     if args.advanced:
         advanced_currency()
+        sys.exit(0)
     if args.library:
         library_currency()
+        sys.exit(0)
     else:
         simple_currency()


### PR DESCRIPTION
Changes:
* merged the library report from @unixsysadmin's fork
* short flag for config change from `-c` to `-f` so as not to conflict with the `--contentview` flag.
* `subscription_status` column returns the `subscription_status_label` field.
* made the script more in line with the Python style guide
* added detail to the readme, including descriptions of each column

Apologies for the messy commit history.