### PR TITLE
Fix applicable errata report output file

### DIFF
--- a/sat6-currency.py
+++ b/sat6-currency.py
@@ -649,7 +649,7 @@ def library_currency():
                     # Delete any commas from the errata title
                     # eg: https://access.redhat.com/errata/RHSA-2017:0817
                     errata["title"] = errata["title"].replace(',', '')
-                    available_file.write(
+                    applicable_file.write(
                         ','.join(str(x) for x in [
                             str(host["id"]),
                             str(host["organization_name"]),


### PR DESCRIPTION
When running with the '-l' option (library report) - two files are generated.  One for available errata, one for applicable errata.  This fixes a typo to make sure the correct results go into the applicable report.